### PR TITLE
feat: Add GitHub stars counter with NumberTicker animation

### DIFF
--- a/frontend/app/api/github-stars/route.ts
+++ b/frontend/app/api/github-stars/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const response = await fetch('https://api.github.com/repos/adithya-s-k/GitVizz', {
+      headers: {
+        'Accept': 'application/vnd.github.v3+json',
+        'User-Agent': 'GitVizz',
+      },
+      next: { revalidate: 3600 }, // Cache for 1 hour
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch GitHub stars');
+    }
+
+    const data = await response.json();
+    return NextResponse.json({ stars: data.stargazers_count });
+  } catch (error) {
+    console.error('Error fetching GitHub stars:', error);
+    // Return fallback value
+    return NextResponse.json({ stars: 37 });
+  }
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useResultData } from '@/context/ResultDataContext';
-import { useEffect, Suspense } from 'react';
+import { useEffect, Suspense, useState } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { Badge } from '@/components/ui/badge';
@@ -13,6 +13,7 @@ import {
   DialogTitle,
   DialogDescription,
 } from '@/components/ui/dialog';
+import { NumberTicker } from '@/components/ui/number-ticker';
 
 // Custom Components
 import { RepoTabs } from '@/components/repo-tabs';
@@ -25,6 +26,14 @@ function HomeContent() {
   const searchParams = useSearchParams();
   const router = useRouter();
   const prefilledRepo = searchParams.get('repo');
+  const [stars, setStars] = useState(37);
+
+  useEffect(() => {
+    fetch('/api/github-stars')
+      .then((res) => res.json())
+      .then((data) => setStars(data.stars))
+      .catch(() => setStars(37)); // Fallback to default
+  }, []);
 
   // Clean up URL after prefill is detected and processed
   useEffect(() => {
@@ -102,7 +111,7 @@ function HomeContent() {
       {/* Open Source Badge */}
       <div className="flex justify-center mb-4 relative z-10">
         <a
-          href="https://github.com/adithya-s-k/gitvizz"
+          href="https://github.com/adithya-s-k/GitVizz"
           target="_blank"
           rel="noopener noreferrer"
           className="group"
@@ -113,7 +122,10 @@ function HomeContent() {
           >
             <Github className="h-4 w-4 mr-2" />
             <span className="font-semibold">Proudly Open Source</span>
-            <Star className="h-4 w-4 ml-2 group-hover:text-yellow-500 transition-colors" />
+            <div className="flex items-center gap-1 ml-2">
+              <Star className="h-4 w-4 group-hover:text-yellow-500 transition-colors fill-yellow-500 text-yellow-500" />
+              <NumberTicker value={stars} className="text-sm font-semibold" />
+            </div>
           </Badge>
         </a>
       </div>

--- a/frontend/components.json
+++ b/frontend/components.json
@@ -10,6 +10,7 @@
     "cssVariables": true,
     "prefix": ""
   },
+  "iconLibrary": "lucide",
   "aliases": {
     "components": "@/components",
     "utils": "@/lib/utils",
@@ -17,5 +18,7 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "registries": {
+    "@magicui": "https://magicui.design/r/{name}.json"
+  }
 }

--- a/frontend/components/SigmaGraphInner.tsx
+++ b/frontend/components/SigmaGraphInner.tsx
@@ -1095,6 +1095,7 @@ export default function SigmaGraphInner({
   const [applyLayoutRef, setApplyLayoutRef] = useState<
     ((layoutType: string, animate?: boolean) => void) | null
   >(null);
+  const [forceShowLargeGraph, setForceShowLargeGraph] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
   // Reset layout state when data changes
@@ -1125,7 +1126,7 @@ export default function SigmaGraphInner({
   const showPerformanceWarning = nodeCount > 3000;
   const showMaxWarning = nodeCount > 10000;
 
-  if (showMaxWarning) {
+  if (showMaxWarning && !forceShowLargeGraph) {
     return (
       <div className="flex justify-center items-center h-full">
         <div className="text-center space-y-4 p-8 max-w-md">
@@ -1138,7 +1139,17 @@ export default function SigmaGraphInner({
               This graph has {nodeCount.toLocaleString()} nodes, which exceeds the 10,000 node limit
               for optimal performance.
             </p>
+            <p className="text-sm text-muted-foreground">
+              Rendering this graph may affect performance and could potentially crash your browser.
+            </p>
           </div>
+          <Button
+            variant="outline"
+            onClick={() => setForceShowLargeGraph(true)}
+            className="rounded-xl text-sm"
+          >
+            Show graph anyway
+          </Button>
         </div>
       </div>
     );

--- a/frontend/components/footer.tsx
+++ b/frontend/components/footer.tsx
@@ -1,6 +1,19 @@
+'use client';
+
 import { Github, Globe, Star } from 'lucide-react';
+import { NumberTicker } from '@/components/ui/number-ticker';
+import { useEffect, useState } from 'react';
 
 const Footer = () => {
+  const [stars, setStars] = useState(37);
+
+  useEffect(() => {
+    fetch('/api/github-stars')
+      .then((res) => res.json())
+      .then((data) => setStars(data.stars))
+      .catch(() => setStars(37)); // Fallback to default
+  }, []);
+
   return (
     <footer className="relative w-full bottom-0 z-10 border-t border-border/50 bg-background/80 backdrop-blur-sm mt-4">
       <div className="max-w-7xl mx-auto px-6 py-6">
@@ -8,7 +21,7 @@ const Footer = () => {
         <div className="flex flex-col md:flex-row items-center justify-between gap-4 mb-4">
           <div className="flex items-center gap-4">
             <a
-              href="https://github.com/adithya-s-k/gitvizz"
+              href="https://github.com/adithya-s-k/GitVizz"
               target="_blank"
               rel="noopener noreferrer"
               aria-label="GitHub Repository"
@@ -16,7 +29,10 @@ const Footer = () => {
             >
               <Github className="h-5 w-5 group-hover:scale-110 transition-transform" />
               <span>Proudly Open Source</span>
-              <Star className="h-4 w-4 group-hover:text-yellow-500 transition-colors" />
+              <div className="flex items-center gap-1">
+                <Star className="h-4 w-4 group-hover:text-yellow-500 transition-colors fill-yellow-500 text-yellow-500" />
+                <NumberTicker value={stars} className="text-sm font-semibold" />
+              </div>
             </a>
             <div className="hidden md:block h-4 border-l border-border/30" />
             <a

--- a/frontend/components/ui/number-ticker.tsx
+++ b/frontend/components/ui/number-ticker.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { ComponentPropsWithoutRef, useEffect, useRef } from "react"
+import { useInView, useMotionValue, useSpring } from "motion/react"
+
+import { cn } from "@/lib/utils"
+
+interface NumberTickerProps extends ComponentPropsWithoutRef<"span"> {
+  value: number
+  startValue?: number
+  direction?: "up" | "down"
+  delay?: number
+  decimalPlaces?: number
+}
+
+export function NumberTicker({
+  value,
+  startValue = 0,
+  direction = "up",
+  delay = 0,
+  className,
+  decimalPlaces = 0,
+  ...props
+}: NumberTickerProps) {
+  const ref = useRef<HTMLSpanElement>(null)
+  const motionValue = useMotionValue(direction === "down" ? value : startValue)
+  const springValue = useSpring(motionValue, {
+    damping: 60,
+    stiffness: 100,
+  })
+  const isInView = useInView(ref, { once: true, margin: "0px" })
+
+  useEffect(() => {
+    if (isInView) {
+      const timer = setTimeout(() => {
+        motionValue.set(direction === "down" ? startValue : value)
+      }, delay * 1000)
+      return () => clearTimeout(timer)
+    }
+  }, [motionValue, isInView, delay, value, direction, startValue])
+
+  useEffect(
+    () =>
+      springValue.on("change", (latest) => {
+        if (ref.current) {
+          ref.current.textContent = Intl.NumberFormat("en-US", {
+            minimumFractionDigits: decimalPlaces,
+            maximumFractionDigits: decimalPlaces,
+          }).format(Number(latest.toFixed(decimalPlaces)))
+        }
+      }),
+    [springValue, decimalPlaces]
+  )
+
+  return (
+    <span
+      ref={ref}
+      className={cn(
+        "inline-block tracking-wider text-black tabular-nums dark:text-white",
+        className
+      )}
+      {...props}
+    >
+      {startValue}
+    </span>
+  )
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,6 +60,7 @@
     "lucide-react": "^0.508.0",
     "mermaid": "^11.8.1",
     "monaco-editor": "^0.52.2",
+    "motion": "^12.23.22",
     "next": "15.3.2",
     "next-auth": "5.0.0-beta.28",
     "next-themes": "^0.4.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       monaco-editor:
         specifier: ^0.52.2
         version: 0.52.2
+      motion:
+        specifier: ^12.23.22
+        version: 12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: 15.3.2
         version: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -2954,6 +2957,20 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  framer-motion@12.23.22:
+    resolution: {integrity: sha512-ZgGvdxXCw55ZYvhoZChTlG6pUuehecgvEAJz0BHoC5pQKW1EC5xf1Mul1ej5+ai+pVY0pylyFfdl45qnM1/GsA==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   fs-minipass@2.1.0:
     resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
     engines: {node: '>= 8'}
@@ -3777,6 +3794,26 @@ packages:
 
   monaco-editor@0.52.2:
     resolution: {integrity: sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==}
+
+  motion-dom@12.23.21:
+    resolution: {integrity: sha512-5xDXx/AbhrfgsQmSE7YESMn4Dpo6x5/DTZ4Iyy4xqDvVHWvFVoV+V2Ri2S/ksx+D40wrZ7gPYiMWshkdoqNgNQ==}
+
+  motion-utils@12.23.6:
+    resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion@12.23.22:
+    resolution: {integrity: sha512-iSq6X9vLHbeYwmHvhK//+U74ROaPnZmBuy60XZzqNl0QtZkWfoZyMDHYnpKuWFv0sNMqHgED8aCXk94LCoQPGg==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -7376,8 +7413,8 @@ snapshots:
       '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react: 7.37.5(eslint@9.28.0(jiti@2.4.2))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.28.0(jiti@2.4.2))
@@ -7396,7 +7433,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -7407,22 +7444,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.9.0
     optionalDependencies:
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3)
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0)(eslint@9.28.0(jiti@2.4.2))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7433,7 +7470,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.28.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.28.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.34.0(eslint@9.28.0(jiti@2.4.2))(typescript@5.8.3))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2)))(eslint@9.28.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7644,6 +7681,15 @@ snapshots:
       is-callable: 1.2.7
 
   format@0.2.2: {}
+
+  framer-motion@12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      motion-dom: 12.23.21
+      motion-utils: 12.23.6
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   fs-minipass@2.1.0:
     dependencies:
@@ -8727,6 +8773,20 @@ snapshots:
       obliterator: 2.0.5
 
   monaco-editor@0.52.2: {}
+
+  motion-dom@12.23.21:
+    dependencies:
+      motion-utils: 12.23.6
+
+  motion-utils@12.23.6: {}
+
+  motion@12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      framer-motion: 12.23.22(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   ms@2.1.3: {}
 


### PR DESCRIPTION
## Summary
- Added GitHub stars API integration to fetch live star count
- Implemented NumberTicker component for animated star count display
- Integrated stars counter in both footer and homepage "Proudly Open Source" sections
- Added option to bypass 10k node limit in Sigma.js graph visualization

## Changes Made
1. **API Route** (`frontend/app/api/github-stars/route.ts`):
   - Fetches GitHub stars from public API
   - Caches results for 1 hour
   - Includes fallback to default value

2. **NumberTicker Component** (`frontend/components/ui/number-ticker.tsx`):
   - Animated number counter using Framer Motion
   - Configurable direction (up/down), delay, and decimal places
   - Smooth spring animation for visual appeal

3. **UI Updates**:
   - Footer: Shows animated star count next to GitHub icon
   - Homepage Badge: Displays star count in "Proudly Open Source" badge
   - Both components fetch and display live GitHub stars

4. **Graph Visualization**:
   - Added option to bypass 10k node limit in Sigma.js graph

## Test Plan
- [x] Verify API route returns correct star count
- [x] Test NumberTicker animation on page load
- [x] Confirm footer displays stars correctly
- [x] Verify homepage badge shows stars
- [x] Test fallback behavior if API fails
- [x] Check responsive design on mobile/desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)